### PR TITLE
Allow alternate Install Path and update Asset Parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ impl From<Arch> for &str {
 		match val {
 			Arch::X64 => "x64",
 			Arch::ARM64 => "arm64",
+
 		}
 	}
 }
@@ -102,6 +103,11 @@ impl Config {
 	fn save(&self) -> Result<()> {
 		fs::write(&*CONFIG_PATH, toml::to_string(self)?)?;
 		Ok(())
+	}
+
+	pub fn restart(&self) {
+		kill_ptr().unwrap_or_else(|e| println!("Failed to kill PowerToys: {}", e));
+		start_ptr().unwrap_or_else(|e| exit!("Failed to start PowerToys: {}", e));
 	}
 
 	pub fn add(&mut self, name: String, repo: String, version: Option<String>) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ enum TopCommand {
 	#[clap(visible_alias = "i")]
 	/// Import plugins from configuration file.
 	Import,
+
+	#[clap()]
+	/// Restart PowerToys
+	Restart,
 }
 
 fn get_styles() -> clap::builder::Styles {
@@ -101,6 +105,7 @@ fn main() {
 			TopCommand::Remove { name } => config.remove(name),
 			TopCommand::List => print!("{}", config),
 			TopCommand::Import => config.import(),
+			TopCommand::Restart => config.restart(),
 		},
 		Err(e) => exit!(e),
 	}

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,8 +4,8 @@ use reqwest::header::{HeaderMap, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::fs::{self, File};
 use std::io::{self, Write};
-use std::mem;
-use std::path::Path;
+use std::{env, mem};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use zip::ZipArchive;
 
@@ -81,7 +81,10 @@ pub fn gh_dl(
 	let asset = &res
 		.assets
 		.iter()
-		.find(|a| a.name.contains(arch))
+		.find(|a|
+			(a.name.contains(arch) || a.name.contains(&arch.to_uppercase()))
+				&& a.name.ends_with(".zip")
+		)
 		.ok_or(anyhow!("No asset found than contains '{}'", arch))?;
 	let (url, name) = (&asset.browser_download_url, &asset.name);
 	let res = Client::new().get(url).send()?;
@@ -169,9 +172,25 @@ pub fn kill_ptr() -> Result<()> {
 }
 
 pub fn start_ptr() -> Result<()> {
-	let c = Command::new("C:\\Program Files\\PowerToys\\PowerToys.exe").spawn()?;
+	let powertoys_path = get_powertoys_path()?;
+	let c = Command::new(powertoys_path).spawn()?;
 	mem::forget(c);
 	Ok(())
+}
+
+fn get_powertoys_path() -> Result<String> {
+	let possible_paths = [
+		PathBuf::from(r"C:\Program Files\PowerToys\PowerToys.exe"),
+		env::var("LOCALAPPDATA")
+			.map(|app_data| PathBuf::from(app_data).join(r"PowerToys\PowerToys.exe"))
+			.unwrap_or_else(|_| PathBuf::new()),
+	];
+	for path in &possible_paths {
+		if path.exists() {
+			return Ok(path.to_path_buf().to_string_lossy().to_string());
+		}
+	}
+	Err(anyhow!("PowerToys executable not found in any of the expected locations"))
 }
 
 #[macro_export]


### PR DESCRIPTION

`ptr` should now check for system install and user install such as over winget
> My powertoys is installed under: `%LOCALAPPDATA%\AppData\Local\PowerToys`

Additionally, parsing of the architecture in case the asset on release is named `ARM64` is improved as well as checking for `.zip` extension
- [ Currency-Converter](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter/releases) provided an installer like `CurrencyConverter-1.3.0-x64.exe` which got detected wrong (as the zip)
-  some assets are name `<name>-<version>-ARM64` instead of `<name>-<version>-arm64` in their zip release like `CurrencyConverter-1.3.0-ARM64.zip` which lead to not finding the correct zip to download

I also added a `restart` command, which was helpful to me when something went wrong, though this could be removed

Seems to work well with more plugins now on my system (arm64) 

*I'm not really fluent with rust so apologies if something (probably) could be done better*
